### PR TITLE
Refactor to use parameters, update GHA workflows, and apply formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,64 @@
+---
+Language:        Cpp
+# BasedOnStyle: JUCE (Custom)
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakAfterJavaFieldAnnotations: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList : BeforeColon
+BreakStringLiterals: false
+ColumnLimit: 0
+# ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: true
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+PackConstructorInitializers: CurrentLine
+PointerAlignment: Left
+ReflowComments: false
+SortIncludes: true
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeParens: NonEmptyParentheses
+SpaceInEmptyParentheses: false
+SpaceBeforeInheritanceColon: true
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: "c++17"
+TabWidth: 4
+UseTab: Never
+---
+

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,11 +2,11 @@ name: linux
 
 on: 
   push:
-    branches: [main,juce8]
+    branches: [main,juce8,testing-juce8]
   pull_request:
     
 env:
-  artifactoryApiKey: ${{ secrets.artifactoryApiKey }}
+  ARTIFACTORY_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
   build_dir: "Build"
   package: EphysSocket-linux
 
@@ -20,7 +20,14 @@ jobs:
       
     - name: set env vars
       run: |
-        echo "GUI_BRANCH=development-juce8" >> "$GITHUB_ENV"
+        if [ ${{github.ref_name}} == 'juce8' ]; then
+          echo "GUI_BRANCH=development-juce8" >> "$GITHUB_ENV"
+        elif [ ${{github.ref_name}} == 'testing-juce8' ]; then
+          echo "GUI_BRANCH=testing-juce8" >> "$GITHUB_ENV"
+        else
+          echo "Invalid branch : ${{github.ref_name}}"
+          exit 1
+        fi
 
     - name: setup
       run: |
@@ -38,7 +45,7 @@ jobs:
         make
 
     - name: deploy
-      if: github.ref == 'refs/heads/juce8' && steps.build.outcome == 'success'
+      if: github.ref == 'refs/heads/testing-juce8' && steps.build.outcome == 'success'
       run: |
         plugin_api=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]*" | tail -1)
         tag=$(grep -w Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")
@@ -47,4 +54,4 @@ jobs:
         cp -r $build_dir/*.so plugins
         zipfile=${package}_${new_plugin_ver}.zip
         zip -r -X $zipfile plugins
-        curl -H "X-JFrog-Art-Api:$artifactoryApiKey" -T $zipfile "https://openephys.jfrog.io/artifactory/EphysSocket-plugin/linux/$zipfile"
+        curl -H "X-JFrog-Art-Api:$ARTIFACTORY_ACCESS_TOKEN" -T $zipfile "https://openephys.jfrog.io/artifactory/EphysSocket-plugin/linux/$zipfile"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,7 @@ name: linux
 
 on: 
   push:
-    branches: [main]
+    branches: [main,juce8]
   pull_request:
     
 env:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -2,7 +2,7 @@ name: mac
 
 on: 
   push:
-    branches: [main]
+    branches: [main,juce8]
   pull_request:
 
 env:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -2,11 +2,11 @@ name: mac
 
 on: 
   push:
-    branches: [main,juce8]
+    branches: [main,juce8,testing-juce8]
   pull_request:
 
 env:
-  artifactoryApiKey: ${{ secrets.artifactoryApiKey }}
+  ARTIFACTORY_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
   build_dir: "Build/Release"
   package: EphysSocket-mac
 
@@ -20,7 +20,14 @@ jobs:
       
     - name: set env vars
       run: |
-        echo "GUI_BRANCH=development-juce8" >> "$GITHUB_ENV"
+        if [ ${{github.ref_name}} == 'juce8' ]; then
+          echo "GUI_BRANCH=development-juce8" >> "$GITHUB_ENV"
+        elif [ ${{github.ref_name}} == 'testing-juce8' ]; then
+          echo "GUI_BRANCH=testing-juce8" >> "$GITHUB_ENV"
+        else
+          echo "Invalid branch : ${{github.ref_name}}"
+          exit 1
+        fi
 
     - name: setup
       run: |
@@ -36,13 +43,67 @@ jobs:
         xcodebuild -configuration Release
 
     - name: deploy
-      if: github.ref == 'refs/heads/juce8' && steps.build.outcome == 'success'
+      if: github.ref == 'refs/heads/testing-juce8' && steps.build.outcome == 'success'
+      env:
+        MACOS_CERTIFICATE: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        MACOS_CERTIFICATE_PWD: ${{ secrets.BUILD_CERTIFICATE_PWD }}
+        MACOS_CERTIFICATE_NAME: ${{ secrets.BUILD_CERTIFICATE_NAME }}
+        MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
+        PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+        PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+        PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
       run: |
         plugin_api=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]" | tail -1)
         tag=$(grep -w Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")
         new_plugin_ver=$tag-API$plugin_api
+
         mkdir plugins 
         cp -r $build_dir/*.bundle plugins
+
+        # Turn our base64-encoded certificate back to a regular .p12 file
+        echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+
+        # We need to create a new keychain, otherwise using the certificate will prompt
+        # with a UI dialog asking for the certificate password, which we can't
+        # use in a headless CI environment
+        security create-keychain -p $MACOS_CI_KEYCHAIN_PWD build.keychain
+        security default-keychain -s build.keychain
+        security unlock-keychain -p $MACOS_CI_KEYCHAIN_PWD build.keychain
+        security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_CI_KEYCHAIN_PWD build.keychain
+        /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" -v plugins/ephys-socket.bundle --deep --strict --timestamp --options=runtime
+
+        /usr/bin/codesign -dv --verbose=4 plugins/ephys-socket.bundle
+
+        # Store the notarization credentials so that we can prevent a UI password dialog from blocking the CI
+
+        echo "Create keychain profile"
+        xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
+
+        # We can't notarize an app bundle directly, but we need to compress it as an archive.
+        # Therefore, we create a zip file containing our app bundle, so that we can send it to the
+        # notarization service
+
+        echo "Creating temp notarization archive"
+        /usr/bin/ditto -c -k --sequesterRsrc --keepParent  plugins/ephys-socket.bundle ephys-socket.zip
+
+        # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
+        # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
+        # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
+        # you're curious
+
+        echo "Notarize app"
+        xcrun notarytool submit "ephys-socket.zip" --keychain-profile "notarytool-profile" --wait
+
+        # Finally, we need to "attach the staple" to our executable, which will allow our app to be
+        # validated by macOS even when an internet connection is not available.
+        echo "Attach staple"
+        rm -r plugins/*
+        /usr/bin/ditto -x -k ephys-socket.zip plugins
+        xcrun stapler staple plugins/ephys-socket.bundle
+
+        spctl -vvv --assess --type exec plugins/ephys-socket.bundle
+
         zipfile=${package}_${new_plugin_ver}.zip
-        zip -r -X $zipfile plugins
-        curl -H "X-JFrog-Art-Api:$artifactoryApiKey" -T $zipfile "https://openephys.jfrog.io/artifactory/EphysSocket-plugin/mac/$zipfile"
+        /usr/bin/ditto -c -k --sequesterRsrc --keepParent plugins $zipfile
+        curl -H "X-JFrog-Art-Api:$ARTIFACTORY_ACCESS_TOKEN" -T $zipfile "https://openephys.jfrog.io/artifactory/EphysSocket-plugin/mac/$zipfile"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,11 +2,11 @@ name: Windows
 
 on: 
   push:
-    branches: [main,juce8]
+    branches: [main,juce8,testing-juce8]
   pull_request:
 
 env:
-  artifactoryApiKey: ${{ secrets.artifactoryApiKey }}
+  ARTIFACTORY_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
   build_dir: "Build/Release"
   package: EphysSocket-windows
 
@@ -20,8 +20,16 @@ jobs:
       
     - name: set env vars
       run: |
-        echo "GUI_BRANCH=development-juce8" >> "$GITHUB_ENV"
-        echo "GUI_LIB_VERSION=v1.0.0-dev" >> "$GITHUB_ENV"
+        if [ ${{github.ref_name}} == 'juce8' ]; then
+          echo "GUI_BRANCH=development-juce8" >> "$GITHUB_ENV"
+          echo "GUI_LIB_VERSION=v1.0.0-dev" >> "$GITHUB_ENV"
+        elif [ ${{github.ref_name}} == 'testing-juce8' ]; then
+          echo "GUI_BRANCH=testing-juce8" >> "$GITHUB_ENV"
+          echo "GUI_LIB_VERSION=v1.0.0-alpha" >> "$GITHUB_ENV"
+        else
+          echo "Invalid branch : ${{github.ref_name}}"
+          exit 1
+        fi
       shell: bash
 
     - name: setup
@@ -31,7 +39,7 @@ jobs:
         cd plugin-GUI/Build
         cmake -G "Visual Studio 17 2022" -A x64 .. 
         mkdir Release && cd Release
-        curl -L https://openephysgui.jfrog.io/artifactory/Libraries/open-ephys-lib-$GUI_LIB_VERSION.zip --output open-ephys-lib.zip 
+        curl -L https://openephys.jfrog.io/artifactory/GUI-binaries/Libraries/open-ephys-lib-$GUI_LIB_VERSION.zip --output open-ephys-lib.zip 
         unzip open-ephys-lib.zip
       shell: bash
 
@@ -52,7 +60,7 @@ jobs:
       shell: cmd
 
     - name: deploy
-      if: github.ref == 'refs/heads/juce8' && steps.build.outcome == 'success'
+      if: github.ref == 'refs/heads/testing-juce8' && steps.build.outcome == 'success'
       run: |
         plugin_api=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]*" | tail -1)
         tag=$(grep -w Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")
@@ -61,5 +69,5 @@ jobs:
         cp $build_dir/*.dll plugins
         zipfile=${package}_${new_plugin_ver}.zip
         powershell Compress-Archive -Path "plugins" -DestinationPath ${zipfile}
-        curl -H "X-JFrog-Art-Api:$artifactoryApiKey" -T $zipfile "https://openephys.jfrog.io/artifactory/EphysSocket-plugin/windows/$zipfile"
+        curl -H "X-JFrog-Art-Api:$ARTIFACTORY_ACCESS_TOKEN" -T $zipfile "https://openephys.jfrog.io/artifactory/EphysSocket-plugin/windows/$zipfile"
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,7 @@ name: Windows
 
 on: 
   push:
-    branches: [main]
+    branches: [main,juce8]
   pull_request:
 
 env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 get_filename_component(PROJECT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)
 get_filename_component(PLUGIN_NAME ${PROJECT_FOLDER} NAME)
 
-set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "Build architecture for Mac OS X" FORCE)
+set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "Build architecture for Mac OS X" FORCE)
 
 project(OE_PLUGIN_${PLUGIN_NAME})
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
@@ -70,7 +70,7 @@ if(MSVC)
 elseif(LINUX)
 	target_link_libraries(${PLUGIN_NAME} GL X11 Xext Xinerama asound dl freetype pthread rt)
 	set_property(TARGET ${PLUGIN_NAME} APPEND_STRING PROPERTY LINK_FLAGS
-		"-fvisibility=hidden -fPIC -rdynamic -Wl,-rpath='$ORIGIN/../shared' -Wl,-rpath='$ORIGIN/../shared-api8'")
+		"-fvisibility=hidden -fPIC -rdynamic -Wl,-rpath='$ORIGIN/../shared' -Wl,-rpath='$ORIGIN/../shared-api9'")
 	target_compile_options(${PLUGIN_NAME} PRIVATE -fPIC -rdynamic)
 	target_compile_options(${PLUGIN_NAME} PRIVATE -O3) #enable optimization for linux debug
 	
@@ -78,9 +78,9 @@ elseif(LINUX)
 elseif(APPLE)
 	set_target_properties(${PLUGIN_NAME} PROPERTIES BUNDLE TRUE)
 	set_property(TARGET ${PLUGIN_NAME} APPEND_STRING PROPERTY LINK_FLAGS
-	"-undefined dynamic_lookup -rpath @loader_path/../../../../shared-api8")
+	"-undefined dynamic_lookup -rpath @loader_path/../../../../shared-api9")
 
-	install(TARGETS ${PLUGIN_NAME} DESTINATION $ENV{HOME}/Library/Application\ Support/open-ephys/plugins-api8)
+	install(TARGETS ${PLUGIN_NAME} DESTINATION $ENV{HOME}/Library/Application\ Support/open-ephys/plugins-api9)
 endif()
 
 #create filters for vs and xcode

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/Resources/python-example-tcp.py
+++ b/Resources/python-example-tcp.py
@@ -61,14 +61,17 @@ def currentTime():
     return time.time_ns() / (10 ** 9)
 
 # ---- STREAM DATA ---- #
-while (bufferIndex < totalBytes):
-    t1 = currentTime()
-    rc = tcpClient.sendto(header + bytesToSend[bufferIndex:bufferIndex+bytesPerBuffer], address)
-    t2 = currentTime()
-    
-    while ((t2 - t1) < bufferInterval):
+try:
+    while (bufferIndex < totalBytes):
+        t1 = currentTime()
+        rc = tcpClient.sendto(header + bytesToSend[bufferIndex:bufferIndex+bytesPerBuffer], address)
         t2 = currentTime()
-    
-    bufferIndex += bytesPerBuffer
+        
+        while ((t2 - t1) < bufferInterval):
+            t2 = currentTime()
+        
+        bufferIndex += bytesPerBuffer
 
-print("Done")
+    print("Done")
+except BrokenPipeError:
+    print("Connection closed by the server. Unable to send data. Exiting...")

--- a/Source/EphysSocket.cpp
+++ b/Source/EphysSocket.cpp
@@ -7,29 +7,29 @@
 
 using namespace EphysSocketNode;
 
-DataThread* EphysSocket::createDataThread(SourceNode* sn)
+DataThread* EphysSocket::createDataThread (SourceNode* sn)
 {
-	return new EphysSocket(sn);
+    return new EphysSocket (sn);
 }
 
-EphysSocket::EphysSocket(SourceNode* sn) : DataThread(sn), socket("socket_thread", this)
+EphysSocket::EphysSocket (SourceNode* sn) : DataThread (sn), socket ("socket_thread", this)
 {
-	port = DEFAULT_PORT;
-	sample_rate = DEFAULT_SAMPLE_RATE;
+    port = DEFAULT_PORT;
+    sample_rate = DEFAULT_SAMPLE_RATE;
 
-	total_samples = 0;
-	eventState = 0;
+    total_samples = 0;
+    eventState = 0;
 
-	data_scale = DEFAULT_DATA_SCALE;
-	data_offset = DEFAULT_DATA_OFFSET;
+    data_scale = DEFAULT_DATA_SCALE;
+    data_offset = DEFAULT_DATA_OFFSET;
 
-	sourceBuffers.add(new DataBuffer(socket.num_channels, sample_rate * bufferSizeInSeconds)); // start with 2 channels and automatically resize
+    sourceBuffers.add (new DataBuffer (socket.num_channels, sample_rate * bufferSizeInSeconds)); // start with 2 channels and automatically resize
 }
 
-std::unique_ptr<GenericEditor> EphysSocket::createEditor(SourceNode* sn)
+std::unique_ptr<GenericEditor> EphysSocket::createEditor (SourceNode* sn)
 {
-	std::unique_ptr<EphysSocketEditor> editor = std::make_unique<EphysSocketEditor>(sn, this);
-	return editor;
+    std::unique_ptr<EphysSocketEditor> editor = std::make_unique<EphysSocketEditor> (sn, this);
+    return editor;
 }
 
 EphysSocket::~EphysSocket()
@@ -38,333 +38,342 @@ EphysSocket::~EphysSocket()
 
 void EphysSocket::registerParameters()
 {
-	addIntParameter (Parameter::PROCESSOR_SCOPE, "port", "Port", "Port number to connect to", DEFAULT_PORT, MIN_PORT, MAX_PORT);
-	addFloatParameter(Parameter::PROCESSOR_SCOPE, "sample_rate", "Sample Rate", "Sample rate of incoming data", "Hz", DEFAULT_SAMPLE_RATE, MIN_SAMPLE_RATE, MAX_SAMPLE_RATE, 1.0f);
-	addFloatParameter(Parameter::PROCESSOR_SCOPE, "data_scale", "Scale", "Scale of incoming data", "", DEFAULT_DATA_SCALE, MIN_DATA_SCALE, MAX_DATA_SCALE, 0.1f);
-	addFloatParameter(Parameter::PROCESSOR_SCOPE, "data_offset", "Offset", "Offset of incoming data", "", DEFAULT_DATA_OFFSET, MIN_DATA_OFFSET, MAX_DATA_OFFSET, 1.0f);
+    addIntParameter (Parameter::PROCESSOR_SCOPE, "port", "Port", "Port number to connect to", DEFAULT_PORT, MIN_PORT, MAX_PORT);
+    addFloatParameter (Parameter::PROCESSOR_SCOPE, "sample_rate", "Sample Rate", "Sample rate of incoming data", "Hz", DEFAULT_SAMPLE_RATE, MIN_SAMPLE_RATE, MAX_SAMPLE_RATE, 1.0f);
+    addFloatParameter (Parameter::PROCESSOR_SCOPE, "data_scale", "Scale", "Scale of incoming data", "", DEFAULT_DATA_SCALE, MIN_DATA_SCALE, MAX_DATA_SCALE, 0.1f);
+    addFloatParameter (Parameter::PROCESSOR_SCOPE, "data_offset", "Offset", "Offset of incoming data", "", DEFAULT_DATA_OFFSET, MIN_DATA_OFFSET, MAX_DATA_OFFSET, 1.0f);
 }
 
 void EphysSocket::disconnectSocket()
 {
-	socket.disconnectSocket();
+    socket.disconnectSocket();
 
-	getParameter("port")->setEnabled(true);
-	getParameter("sample_rate")->setEnabled(true);
-	getParameter("data_scale")->setEnabled(true);
-	getParameter("data_offset")->setEnabled(true);
+    getParameter ("port")->setEnabled (true);
+    getParameter ("sample_rate")->setEnabled (true);
+    getParameter ("data_scale")->setEnabled (true);
+    getParameter ("data_offset")->setEnabled (true);
 
-	if (sn->getEditor() != nullptr) // check if headless
-		static_cast<EphysSocketEditor*>(sn->getEditor())->disconnected();
+    if (sn->getEditor() != nullptr) // check if headless
+        static_cast<EphysSocketEditor*> (sn->getEditor())->disconnected();
 }
 
-bool EphysSocket::connectSocket(bool printOutput)
+bool EphysSocket::connectSocket (bool printOutput)
 {
-	if (socket.connectSocket(port, printOutput))
-	{
-		getParameter("port")->setEnabled(false);
-		getParameter("sample_rate")->setEnabled(false);
-		getParameter("data_scale")->setEnabled(false);
-		getParameter("data_offset")->setEnabled(false);
+    if (socket.connectSocket (port, printOutput))
+    {
+        getParameter ("port")->setEnabled (false);
+        getParameter ("sample_rate")->setEnabled (false);
+        getParameter ("data_scale")->setEnabled (false);
+        getParameter ("data_offset")->setEnabled (false);
 
-		if (sn->getEditor() != nullptr) // check if headless
-			static_cast<EphysSocketEditor*>(sn->getEditor())->connected();
+        if (sn->getEditor() != nullptr) // check if headless
+            static_cast<EphysSocketEditor*> (sn->getEditor())->connected();
 
-		return true;
-	}
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
 bool EphysSocket::errorFlag()
 {
-	return socket.isError();
+    return socket.isError();
 }
 
 void EphysSocket::resizeBuffers()
 {
-	sourceBuffers[0]->resize(socket.num_channels, sample_rate * bufferSizeInSeconds);
-	convbuf.resize(socket.num_channels * socket.num_samp);
-	sampleNumbers.resize(socket.num_samp);
-	timestamps.clear();
-	timestamps.insertMultiple(0, 0.0, socket.num_samp);
-	ttlEventWords.resize(socket.num_samp);
+    sourceBuffers[0]->resize (socket.num_channels, sample_rate * bufferSizeInSeconds);
+    convbuf.resize (socket.num_channels * socket.num_samp);
+    sampleNumbers.resize (socket.num_samp);
+    timestamps.clear();
+    timestamps.insertMultiple (0, 0.0, socket.num_samp);
+    ttlEventWords.resize (socket.num_samp);
 }
 
-void EphysSocket::updateSettings(OwnedArray<ContinuousChannel>* continuousChannels,
-	OwnedArray<EventChannel>* eventChannels,
-	OwnedArray<SpikeChannel>* spikeChannels,
-	OwnedArray<DataStream>* sourceStreams,
-	OwnedArray<DeviceInfo>* devices,
-	OwnedArray<ConfigurationObject>* configurationObjects)
+void EphysSocket::updateSettings (OwnedArray<ContinuousChannel>* continuousChannels,
+                                  OwnedArray<EventChannel>* eventChannels,
+                                  OwnedArray<SpikeChannel>* spikeChannels,
+                                  OwnedArray<DataStream>* sourceStreams,
+                                  OwnedArray<DeviceInfo>* devices,
+                                  OwnedArray<ConfigurationObject>* configurationObjects)
 {
-	continuousChannels->clear();
-	eventChannels->clear();
-	devices->clear();
-	spikeChannels->clear();
-	configurationObjects->clear();
-	sourceStreams->clear();
+    continuousChannels->clear();
+    eventChannels->clear();
+    devices->clear();
+    spikeChannels->clear();
+    configurationObjects->clear();
+    sourceStreams->clear();
 
-	DataStream::Settings settings
-	{
-		"EphysSocketStream",
-		"Data acquired via network stream",
-		"ephyssocket.data",
+    DataStream::Settings settings {
+        "EphysSocketStream",
+        "Data acquired via network stream",
+        "ephyssocket.data",
 
-		sample_rate
+        sample_rate
 
-	};
+    };
 
-	sourceStreams->add(new DataStream(settings));
-	sourceBuffers[0]->resize(socket.num_channels, sample_rate * bufferSizeInSeconds);
+    sourceStreams->add (new DataStream (settings));
+    sourceBuffers[0]->resize (socket.num_channels, sample_rate * bufferSizeInSeconds);
 
-	for (int ch = 0; ch < socket.num_channels; ch++)
-	{
-		ContinuousChannel::Settings settings{
-			ContinuousChannel::Type::ELECTRODE,
-			"CH" + String(ch + 1),
-			"Channel acquired via network stream",
-			"ephyssocket.continuous",
+    for (int ch = 0; ch < socket.num_channels; ch++)
+    {
+        ContinuousChannel::Settings settings {
+            ContinuousChannel::Type::ELECTRODE,
+            "CH" + String (ch + 1),
+            "Channel acquired via network stream",
+            "ephyssocket.continuous",
 
-			data_scale,
+            data_scale,
 
-			sourceStreams->getFirst()
-		};
+            sourceStreams->getFirst()
+        };
 
-		continuousChannels->add(new ContinuousChannel(settings));
-	}
+        continuousChannels->add (new ContinuousChannel (settings));
+    }
 
-	EventChannel::Settings eventSettings{
-		   EventChannel::Type::TTL,
-		   "Events",
-		   "Events acquired via network stream",
-		   "ephyssocket.events",
-		   sourceStreams->getFirst(),
-		   1
-	};
+    EventChannel::Settings eventSettings {
+        EventChannel::Type::TTL,
+        "Events",
+        "Events acquired via network stream",
+        "ephyssocket.events",
+        sourceStreams->getFirst(),
+        1
+    };
 
-	eventChannels->add(new EventChannel(eventSettings));
+    eventChannels->add (new EventChannel (eventSettings));
 }
 
 bool EphysSocket::foundInputSource()
 {
-	return socket.isConnected();
+    return socket.isConnected();
 }
 
 bool EphysSocket::isReady()
 {
-	return socket.isConnected();
+    return socket.isConnected();
 }
 
-void EphysSocket::parameterValueChanged(Parameter* parameter)
+void EphysSocket::parameterValueChanged (Parameter* parameter)
 {
-	if (parameter->getName() == "port")
-	{
-		port = (int)parameter->getValue();
-	}
-	else if (parameter->getName() == "sample_rate")
-	{
-		sample_rate = (float)parameter->getValue();
-		CoreServices::updateSignalChain (sn); // Update the signal chain to reflect the new sample rate
-	}
-	else if (parameter->getName() == "data_scale")
-	{
-		data_scale = (float)parameter->getValue();
-		CoreServices::updateSignalChain (sn); // Update the signal chain to reflect the new data scale
-	}
-	else if (parameter->getName() == "data_offset")
-	{
-		data_offset = (float)parameter->getValue();
-	}
+    if (parameter->getName() == "port")
+    {
+        port = (int) parameter->getValue();
+    }
+    else if (parameter->getName() == "sample_rate")
+    {
+        sample_rate = (float) parameter->getValue();
+        CoreServices::updateSignalChain (sn); // Update the signal chain to reflect the new sample rate
+    }
+    else if (parameter->getName() == "data_scale")
+    {
+        data_scale = (float) parameter->getValue();
+        CoreServices::updateSignalChain (sn); // Update the signal chain to reflect the new data scale
+    }
+    else if (parameter->getName() == "data_offset")
+    {
+        data_offset = (float) parameter->getValue();
+    }
 }
 
 bool EphysSocket::startAcquisition()
 {
-	resizeBuffers();
+    resizeBuffers();
 
-	total_samples = 0;
-	eventState = 0;
+    total_samples = 0;
+    eventState = 0;
 
-	socket.startAcquisition();
+    socket.startAcquisition();
 
-	socket.startThread();
-	startThread();
+    socket.startThread();
+    startThread();
 
-	return true;
+    return true;
 }
 
 bool EphysSocket::stopAcquisition()
 {
-	if (isThreadRunning())
-	{
-		signalThreadShouldExit();
-	}
+    if (isThreadRunning())
+    {
+        signalThreadShouldExit();
+    }
 
-	socket.stopAcquisition();
+    socket.stopAcquisition();
 
-	sourceBuffers[0]->clear();
-	return true;
+    sourceBuffers[0]->clear();
+    return true;
 }
 
 template <typename T>
-void EphysSocket::convertData(std::vector<std::byte> buffer)
+void EphysSocket::convertData (std::vector<std::byte> buffer)
 {
-	T* buf = (T*)(buffer.data() + HEADER_SIZE);
+    T* buf = (T*) (buffer.data() + HEADER_SIZE);
 
-	for (int i = 0; i < socket.num_samp * socket.num_channels; i++) {
-		convbuf[i] = data_scale * ((float)(buf[i]) - data_offset);
-	}
+    for (int i = 0; i < socket.num_samp * socket.num_channels; i++)
+    {
+        convbuf[i] = data_scale * ((float) (buf[i]) - data_offset);
+    }
 }
 
 bool EphysSocket::updateBuffer()
 {
-	if (socket.isError())
-	{
-		return false;
-	}
+    if (socket.isError())
+    {
+        return false;
+    }
 
-	if (socket.data.isEmpty()) {
-		return true;
-	}
+    if (socket.data.isEmpty())
+    {
+        return true;
+    }
 
-	std::vector<std::byte> data = socket.data.removeAndReturn(0);
-	
-	if (socket.depth == U8) {
-		convertData<uint8_t>(data);
-	}
-	else if (socket.depth == S8) {
-		convertData<int8_t>(data);
-	}
-	else if (socket.depth == U16) {
-		convertData<uint16_t>(data);
-	}
-	else if (socket.depth == S16) {
-		convertData<int16_t>(data);
-	}
-	else if (socket.depth == S32) {
-		convertData<int32_t>(data);
-	}
-	else if (socket.depth == F32) {
-		convertData<float_t>(data);
-	}
-	else if (socket.depth == F64) {
-		convertData<double_t>(data);
-	}
+    std::vector<std::byte> data = socket.data.removeAndReturn (0);
 
-	for (int i = 0; i < socket.num_samp; i++)
-	{
-		sampleNumbers.set(i, total_samples++);
-		ttlEventWords.set(i, eventState);
-	}
+    if (socket.depth == U8)
+    {
+        convertData<uint8_t> (data);
+    }
+    else if (socket.depth == S8)
+    {
+        convertData<int8_t> (data);
+    }
+    else if (socket.depth == U16)
+    {
+        convertData<uint16_t> (data);
+    }
+    else if (socket.depth == S16)
+    {
+        convertData<int16_t> (data);
+    }
+    else if (socket.depth == S32)
+    {
+        convertData<int32_t> (data);
+    }
+    else if (socket.depth == F32)
+    {
+        convertData<float_t> (data);
+    }
+    else if (socket.depth == F64)
+    {
+        convertData<double_t> (data);
+    }
 
-	sourceBuffers[0]->addToBuffer(convbuf.data(),
-		sampleNumbers.getRawDataPointer(),
-		timestamps.getRawDataPointer(),
-		ttlEventWords.getRawDataPointer(),
-		socket.num_samp);
+    for (int i = 0; i < socket.num_samp; i++)
+    {
+        sampleNumbers.set (i, total_samples++);
+        ttlEventWords.set (i, eventState);
+    }
 
-	return true;
+    sourceBuffers[0]->addToBuffer (convbuf.data(),
+                                   sampleNumbers.getRawDataPointer(),
+                                   timestamps.getRawDataPointer(),
+                                   ttlEventWords.getRawDataPointer(),
+                                   socket.num_samp);
+
+    return true;
 }
 
-String EphysSocket::handleConfigMessage(const String& msg)
+String EphysSocket::handleConfigMessage (const String& msg)
 {
-	// Available commands:
-	// ES INFO - Returns info on current variables that can be modified over HTTP
-	// ES SCALE <data_scale>        - Updates the data scale to data_scale
-	// ES OFFSET <data_offset>      - Updates the offset to data_offset
-	// ES PORT <port>               - Updates the port number that EphysSocket connects to
-	// ES FREQUENCY <sample_rate>   - Updates the sampling rate
+    // Available commands:
+    // ES INFO - Returns info on current variables that can be modified over HTTP
+    // ES SCALE <data_scale>        - Updates the data scale to data_scale
+    // ES OFFSET <data_offset>      - Updates the offset to data_offset
+    // ES PORT <port>               - Updates the port number that EphysSocket connects to
+    // ES FREQUENCY <sample_rate>   - Updates the sampling rate
 
-	if (CoreServices::getAcquisitionStatus()) {
-		return "Ephys Socket plugin cannot update settings while acquisition is active.";
-	}
+    if (CoreServices::getAcquisitionStatus())
+    {
+        return "Ephys Socket plugin cannot update settings while acquisition is active.";
+    }
 
-	if (socket.isConnected()) {
-		return "Ephys Socket plugin cannot update settings while connected to an active socket.";
-	}
+    if (socket.isConnected())
+    {
+        return "Ephys Socket plugin cannot update settings while connected to an active socket.";
+    }
 
-	StringArray parts = StringArray::fromTokens(msg, " ", "");
+    StringArray parts = StringArray::fromTokens (msg, " ", "");
 
-	if (parts.size() > 0)
-	{
-		if (parts[0].equalsIgnoreCase("ES"))
-		{
-			if (parts.size() == 3)
-			{
-				if (parts[1].equalsIgnoreCase("SCALE"))
-				{
-					float scale = parts[2].getFloatValue();
+    if (parts.size() > 0)
+    {
+        if (parts[0].equalsIgnoreCase ("ES"))
+        {
+            if (parts.size() == 3)
+            {
+                if (parts[1].equalsIgnoreCase ("SCALE"))
+                {
+                    float scale = parts[2].getFloatValue();
 
-					if (scale > MIN_DATA_SCALE && scale < MAX_DATA_SCALE)
-					{
-						getParameter("data_scale")->setNextValue(scale);
-						LOGC("Scale updated to: ", scale);
-						return "SUCCESS";
-					}
+                    if (scale > MIN_DATA_SCALE && scale < MAX_DATA_SCALE)
+                    {
+                        getParameter ("data_scale")->setNextValue (scale);
+                        LOGC ("Scale updated to: ", scale);
+                        return "SUCCESS";
+                    }
 
-					return "Invalid scale requested. Scale can be set between '" + String(MIN_DATA_SCALE) + "' and '" + String(MAX_DATA_SCALE) + "'";
-				}
-				else if (parts[1].equalsIgnoreCase("OFFSET"))
-				{
-					float offset = parts[2].getFloatValue();
+                    return "Invalid scale requested. Scale can be set between '" + String (MIN_DATA_SCALE) + "' and '" + String (MAX_DATA_SCALE) + "'";
+                }
+                else if (parts[1].equalsIgnoreCase ("OFFSET"))
+                {
+                    float offset = parts[2].getFloatValue();
 
-					if (offset >= MIN_DATA_OFFSET && offset < MAX_DATA_OFFSET)
-					{
-						getParameter("data_offset")->setNextValue(offset);
-						LOGC("Offset updated to: ", offset);
-						return "SUCCESS";
-					}
+                    if (offset >= MIN_DATA_OFFSET && offset < MAX_DATA_OFFSET)
+                    {
+                        getParameter ("data_offset")->setNextValue (offset);
+                        LOGC ("Offset updated to: ", offset);
+                        return "SUCCESS";
+                    }
 
-					return "Invalid offset requested. Offset can be set between '" + String(MIN_DATA_OFFSET) + "' and '" + String(MAX_DATA_OFFSET) + "'";
-				}
-				else if (parts[1].equalsIgnoreCase("PORT"))
-				{
-					float _port = parts[2].getFloatValue();
+                    return "Invalid offset requested. Offset can be set between '" + String (MIN_DATA_OFFSET) + "' and '" + String (MAX_DATA_OFFSET) + "'";
+                }
+                else if (parts[1].equalsIgnoreCase ("PORT"))
+                {
+                    float _port = parts[2].getFloatValue();
 
-					if (_port > MIN_PORT && _port < MAX_PORT)
-					{
-						getParameter("port")->setNextValue(_port);
-						LOGC("Port updated to: ", _port);
-						return "SUCCESS";
-					}
+                    if (_port > MIN_PORT && _port < MAX_PORT)
+                    {
+                        getParameter ("port")->setNextValue (_port);
+                        LOGC ("Port updated to: ", _port);
+                        return "SUCCESS";
+                    }
 
-					return "Invalid port requested. Port can be set between '" + String(MIN_PORT) + "' and '" + String(MAX_PORT) + "'";
-				}
-				else if (parts[1].equalsIgnoreCase("FREQUENCY"))
-				{
-					float frequency = parts[2].getFloatValue();
+                    return "Invalid port requested. Port can be set between '" + String (MIN_PORT) + "' and '" + String (MAX_PORT) + "'";
+                }
+                else if (parts[1].equalsIgnoreCase ("FREQUENCY"))
+                {
+                    float frequency = parts[2].getFloatValue();
 
-					if (frequency > MIN_SAMPLE_RATE && frequency < MAX_SAMPLE_RATE)
-					{
-						getParameter("sample_rate")->setNextValue(frequency);
-						LOGC("Frequency updated to: ", sample_rate);
-						return "SUCCESS";
-					}
+                    if (frequency > MIN_SAMPLE_RATE && frequency < MAX_SAMPLE_RATE)
+                    {
+                        getParameter ("sample_rate")->setNextValue (frequency);
+                        LOGC ("Frequency updated to: ", sample_rate);
+                        return "SUCCESS";
+                    }
 
-					return "Invalid frequency requested. Frequency can be set between '" + String(MIN_SAMPLE_RATE) + "' and '" + String(MAX_SAMPLE_RATE) + "'";
-				}
-				else
-				{
-					return "ES command " + parts[1] + "not recognized.";
-				}
-			}
-			else if (parts.size() == 2)
-			{
-				if (parts[1].equalsIgnoreCase("INFO"))
-				{
-					return "Port = " + String(port) + ". Sample rate = " + String(sample_rate) +
-						"Scale = " + String(data_scale) + ". Offset = " + String(data_offset) + ".";
-				}
-				else
-				{
-					return "ES command " + parts[1] + "not recognized.";
-				}
-			}
+                    return "Invalid frequency requested. Frequency can be set between '" + String (MIN_SAMPLE_RATE) + "' and '" + String (MAX_SAMPLE_RATE) + "'";
+                }
+                else
+                {
+                    return "ES command " + parts[1] + "not recognized.";
+                }
+            }
+            else if (parts.size() == 2)
+            {
+                if (parts[1].equalsIgnoreCase ("INFO"))
+                {
+                    return "Port = " + String (port) + ". Sample rate = " + String (sample_rate) + "Scale = " + String (data_scale) + ". Offset = " + String (data_offset) + ".";
+                }
+                else
+                {
+                    return "ES command " + parts[1] + "not recognized.";
+                }
+            }
 
-			return "Unknown number of inputs given.";
-		}
+            return "Unknown number of inputs given.";
+        }
 
-		return "Command not recognized.";
-	}
+        return "Command not recognized.";
+    }
 
-	return "Empty message";
+    return "Empty message";
 }

--- a/Source/EphysSocket.h
+++ b/Source/EphysSocket.h
@@ -41,6 +41,9 @@ namespace EphysSocketNode
         /** Create the DataThread object*/
         static DataThread* createDataThread(SourceNode* sn);
 
+        /** Registers the parameters for the DataThread */
+        void registerParameters() override;
+
         /** Returns true if socket is connected */
         bool foundInputSource() override;
 
@@ -51,6 +54,9 @@ namespace EphysSocketNode
             OwnedArray<DataStream>* sourceStreams,
             OwnedArray<DeviceInfo>* devices,
             OwnedArray<ConfigurationObject>* configurationObjects);
+
+        /** Handles parameter value changes */
+        void parameterValueChanged(Parameter* parameter) override;
 
         /** Resizes buffers when input parameters are changed*/
         void resizeBuffers();

--- a/Source/EphysSocketEditor.cpp
+++ b/Source/EphysSocketEditor.cpp
@@ -28,118 +28,15 @@ EphysSocketEditor::EphysSocketEditor(GenericProcessor* parentNode, EphysSocket* 
 	addAndMakeVisible(disconnectButton.get());
 	disconnectButton->setVisible(false);
 
-	// Port
-	portLabel = std::make_unique<Label>("Port", "Port");
-	portLabel->setFont(FontOptions("Small Text", 10, Font::plain));
-	portLabel->setBounds(10, 63, 70, 8);
-	portLabel->setColour(Label::textColourId, Colours::darkgrey);
-	addAndMakeVisible(portLabel.get());
+	addTextBoxParameterEditor(Parameter::PROCESSOR_SCOPE, "port", 10, 60);
+	addTextBoxParameterEditor(Parameter::PROCESSOR_SCOPE, "sample_rate", 10, 95);
+	addTextBoxParameterEditor(Parameter::PROCESSOR_SCOPE, "data_scale", 95, 60);
+	addTextBoxParameterEditor(Parameter::PROCESSOR_SCOPE, "data_offset", 95, 95);
 
-	portInput = std::make_unique<Label>("Port", String(node->port));
-	portInput->setFont(FontOptions("Small Text", 10, Font::plain));
-	portInput->setColour(Label::backgroundColourId, Colours::lightgrey);
-	portInput->setEditable(true);
-	portInput->addListener(this);
-	portInput->setBounds(15, 73, 70, 15);
-	addAndMakeVisible(portInput.get());
-
-	// Frequency
-	sampleRateLabel = std::make_unique<Label>("FREQ (HZ)", "Freq (Hz)");
-	sampleRateLabel->setFont(FontOptions("Small Text", 10, Font::plain));
-	sampleRateLabel->setBounds(10, 98, 85, 8);
-	sampleRateLabel->setColour(Label::textColourId, Colours::darkgrey);
-	addAndMakeVisible(sampleRateLabel.get());
-
-	sampleRateInput = std::make_unique<Label>("Fs (Hz)", String((int)node->sample_rate));
-	sampleRateInput->setFont(FontOptions("Small Text", 10, Font::plain));
-	sampleRateInput->setBounds(15, 108, 70, 15);
-	sampleRateInput->setEditable(true);
-	sampleRateInput->setColour(Label::backgroundColourId, Colours::lightgrey);
-	sampleRateInput->addListener(this);
-	addAndMakeVisible(sampleRateInput.get());
-
-	// Scale
-	scaleLabel = std::make_unique<Label>("Scale", "Scale");
-	scaleLabel->setFont(FontOptions("Small Text", 10, Font::plain));
-	scaleLabel->setBounds(95, 63, 85, 8);
-	scaleLabel->setColour(Label::textColourId, Colours::darkgrey);
-	addAndMakeVisible(scaleLabel.get());
-
-	scaleInput = std::make_unique<Label>("Scale", String(node->data_scale));
-	scaleInput->setFont(FontOptions("Small Text", 10, Font::plain));
-	scaleInput->setBounds(100, 73, 70, 15);
-	scaleInput->setEditable(true);
-	scaleInput->setColour(Label::backgroundColourId, Colours::lightgrey);
-	scaleInput->addListener(this);
-	addAndMakeVisible(scaleInput.get());
-
-	// Offset
-	offsetLabel = std::make_unique<Label>("Offset", "Offset");
-	offsetLabel->setFont(FontOptions("Small Text", 10, Font::plain));
-	offsetLabel->setBounds(95, 98, 85, 8);
-	offsetLabel->setColour(Label::textColourId, Colours::darkgrey);
-	addAndMakeVisible(offsetLabel.get());
-
-	offsetInput = std::make_unique<Label>("Offset", String(node->data_offset));
-	offsetInput->setFont(FontOptions("Small Text", 10, Font::plain));
-	offsetInput->setBounds(100, 108, 70, 15);
-	offsetInput->setEditable(true);
-	offsetInput->setColour(Label::backgroundColourId, Colours::lightgrey);
-	offsetInput->addListener(this);
-	addAndMakeVisible(offsetInput.get());
-}
-
-void EphysSocketEditor::labelTextChanged(Label* label)
-{
-	if (label == sampleRateInput.get())
+	for (auto& ed : parameterEditors)
 	{
-		float sampleRate = sampleRateInput->getText().getFloatValue();
-
-		if (sampleRate > node->MIN_SAMPLE_RATE && sampleRate < node->MAX_SAMPLE_RATE)
-		{
-			node->sample_rate = sampleRate;
-			CoreServices::updateSignalChain(this);
-		}
-		else {
-			sampleRateInput->setText(String(node->sample_rate), dontSendNotification);
-		}
-	}
-	else if (label == portInput.get())
-	{
-		int port = portInput->getText().getIntValue();
-
-		if (port > node->MIN_PORT && port < node->MAX_PORT)
-		{
-			node->port = port;
-		}
-		else {
-			portInput->setText(String(node->port), dontSendNotification);
-		}
-	}
-	else if (label == scaleInput.get())
-	{
-		float scale = scaleInput->getText().getFloatValue();
-
-		if (scale > node->MIN_DATA_SCALE && scale < node->MAX_DATA_SCALE)
-		{
-			node->data_scale = scale;
-			CoreServices::updateSignalChain(this);
-		}
-		else {
-			scaleInput->setText(String(node->data_scale), dontSendNotification);
-		}
-	}
-	else if (label == offsetInput.get())
-	{
-		int offset = offsetInput->getText().getIntValue();
-
-		if (offset >= node->MIN_DATA_OFFSET && offset < node->MAX_DATA_OFFSET)
-		{
-			node->data_offset = offset;
-		}
-		else {
-			offsetInput->setText(String(node->data_offset), dontSendNotification);
-		}
+		ed->setLayout (ParameterEditor::Layout::nameOnTop);
+		ed->setBounds (ed->getX(), ed->getY(), 80, 30);
 	}
 }
 
@@ -154,83 +51,34 @@ void EphysSocketEditor::stopAcquisition()
 	if (node->errorFlag())
 	{
 		node->disconnectSocket();
-		enableInputs();
 	}
 
 	disconnectButton->setEnabled(true);
 	disconnectButton->setAlpha(1.0f);
 }
 
-void EphysSocketEditor::disableInputs()
-{
-	connectButton->setVisible(false);
-	disconnectButton->setVisible(true);
-
-	portInput->setEnabled(false);
-	sampleRateInput->setEnabled(false);
-	scaleInput->setEnabled(false);
-	offsetInput->setEnabled(false);
-}
-
-void EphysSocketEditor::enableInputs()
-{
-	connectButton->setVisible(true);
-	disconnectButton->setVisible(false);
-
-	portInput->setEnabled(true);
-	sampleRateInput->setEnabled(true);
-	scaleInput->setEnabled(true);
-	offsetInput->setEnabled(true);
-}
-
 void EphysSocketEditor::buttonClicked(Button* button)
 {
 	if (button == connectButton.get() && !acquisitionIsActive)
 	{
-		node->port = portInput->getText().getIntValue();
-
-		if (node->connectSocket())
-		{
-			disableInputs();
-		}
+		node->connectSocket();
 
 		CoreServices::updateSignalChain(this);
 	}
 	else if (button == disconnectButton.get() && !acquisitionIsActive)
 	{
 		node->disconnectSocket();
-		enableInputs();
 	}
 }
 
-void EphysSocketEditor::saveCustomParametersToXml(XmlElement* xmlNode)
+void EphysSocketEditor::connected()
 {
-	XmlElement* parameters = xmlNode->createNewChildElement("PARAMETERS");
-
-	parameters->setAttribute("port", portInput->getText());
-	parameters->setAttribute("fs", sampleRateInput->getText());
-	parameters->setAttribute("scale", scaleInput->getText());
-	parameters->setAttribute("offset", offsetInput->getText());
+	connectButton->setVisible(false);
+	disconnectButton->setVisible(true);
 }
 
-void EphysSocketEditor::loadCustomParametersFromXml(XmlElement* xmlNode)
+void EphysSocketEditor::disconnected()
 {
-	forEachXmlChildElement(*xmlNode, subNode)
-	{
-		if (subNode->hasTagName("PARAMETERS"))
-		{
-			portInput->setText(subNode->getStringAttribute("port", ""), dontSendNotification);
-			node->port = subNode->getIntAttribute("port", node->DEFAULT_PORT);
-
-			sampleRateInput->setText(subNode->getStringAttribute("fs", ""), dontSendNotification);
-			node->sample_rate = subNode->getDoubleAttribute("fs", node->DEFAULT_SAMPLE_RATE);
-
-			scaleInput->setText(subNode->getStringAttribute("scale", ""), dontSendNotification);
-			node->data_scale = subNode->getDoubleAttribute("scale", node->DEFAULT_DATA_SCALE);
-
-			offsetInput->setText(subNode->getStringAttribute("offset", ""), dontSendNotification);
-			node->data_offset = subNode->getIntAttribute("offset", node->DEFAULT_DATA_OFFSET);
-		}
-	}
+	connectButton->setVisible(true);
+	disconnectButton->setVisible(false);
 }
-

--- a/Source/EphysSocketEditor.cpp
+++ b/Source/EphysSocketEditor.cpp
@@ -1,84 +1,84 @@
 #include "EphysSocketEditor.h"
 #include "EphysSocket.h"
 
-#include <string>
 #include <iostream>
+#include <string>
 
 using namespace EphysSocketNode;
 
-EphysSocketEditor::EphysSocketEditor(GenericProcessor* parentNode, EphysSocket* socket) : GenericEditor(parentNode)
+EphysSocketEditor::EphysSocketEditor (GenericProcessor* parentNode, EphysSocket* socket) : GenericEditor (parentNode)
 {
-	node = socket;
+    node = socket;
 
-	desiredWidth = 180;
+    desiredWidth = 180;
 
-	// Add connect button
-	connectButton = std::make_unique<UtilityButton>(stringConnect);
-	connectButton->setFont(FontOptions("Small Text", 12, Font::bold));
-	connectButton->setRadius(3.0f);
-	connectButton->setBounds(15, 35, 70, 20);
-	connectButton->addListener(this);
-	addAndMakeVisible(connectButton.get());
+    // Add connect button
+    connectButton = std::make_unique<UtilityButton> (stringConnect);
+    connectButton->setFont (FontOptions ("Small Text", 12, Font::bold));
+    connectButton->setRadius (3.0f);
+    connectButton->setBounds (15, 35, 70, 20);
+    connectButton->addListener (this);
+    addAndMakeVisible (connectButton.get());
 
-	disconnectButton = std::make_unique<UtilityButton>(stringDisconnect);
-	disconnectButton->setFont(FontOptions("Small Text", 12, Font::bold));
-	disconnectButton->setRadius(3.0f);
-	disconnectButton->setBounds(15, 35, 70, 20);
-	disconnectButton->addListener(this);
-	addAndMakeVisible(disconnectButton.get());
-	disconnectButton->setVisible(false);
+    disconnectButton = std::make_unique<UtilityButton> (stringDisconnect);
+    disconnectButton->setFont (FontOptions ("Small Text", 12, Font::bold));
+    disconnectButton->setRadius (3.0f);
+    disconnectButton->setBounds (15, 35, 70, 20);
+    disconnectButton->addListener (this);
+    addAndMakeVisible (disconnectButton.get());
+    disconnectButton->setVisible (false);
 
-	addTextBoxParameterEditor(Parameter::PROCESSOR_SCOPE, "port", 10, 60);
-	addTextBoxParameterEditor(Parameter::PROCESSOR_SCOPE, "sample_rate", 10, 95);
-	addTextBoxParameterEditor(Parameter::PROCESSOR_SCOPE, "data_scale", 95, 60);
-	addTextBoxParameterEditor(Parameter::PROCESSOR_SCOPE, "data_offset", 95, 95);
+    addTextBoxParameterEditor (Parameter::PROCESSOR_SCOPE, "port", 10, 60);
+    addTextBoxParameterEditor (Parameter::PROCESSOR_SCOPE, "sample_rate", 10, 95);
+    addTextBoxParameterEditor (Parameter::PROCESSOR_SCOPE, "data_scale", 95, 60);
+    addTextBoxParameterEditor (Parameter::PROCESSOR_SCOPE, "data_offset", 95, 95);
 
-	for (auto& ed : parameterEditors)
-	{
-		ed->setLayout (ParameterEditor::Layout::nameOnTop);
-		ed->setBounds (ed->getX(), ed->getY(), 80, 30);
-	}
+    for (auto& ed : parameterEditors)
+    {
+        ed->setLayout (ParameterEditor::Layout::nameOnTop);
+        ed->setBounds (ed->getX(), ed->getY(), 80, 30);
+    }
 }
 
 void EphysSocketEditor::startAcquisition()
 {
-	disconnectButton->setEnabled(false);
-	disconnectButton->setAlpha(0.2f);
+    disconnectButton->setEnabled (false);
+    disconnectButton->setAlpha (0.2f);
 }
 
 void EphysSocketEditor::stopAcquisition()
 {
-	if (node->errorFlag())
-	{
-		node->disconnectSocket();
-	}
+    if (node->errorFlag())
+    {
+        node->disconnectSocket();
+    }
 
-	disconnectButton->setEnabled(true);
-	disconnectButton->setAlpha(1.0f);
+    disconnectButton->setEnabled (true);
+    disconnectButton->setAlpha (1.0f);
 }
 
-void EphysSocketEditor::buttonClicked(Button* button)
+void EphysSocketEditor::buttonClicked (Button* button)
 {
-	if (button == connectButton.get() && !acquisitionIsActive)
-	{
-		node->connectSocket();
+    if (button == connectButton.get() && ! acquisitionIsActive)
+    {
+        node->connectSocket();
 
-		CoreServices::updateSignalChain(this);
-	}
-	else if (button == disconnectButton.get() && !acquisitionIsActive)
-	{
-		node->disconnectSocket();
-	}
+        CoreServices::updateSignalChain (this);
+    }
+    else if (button == disconnectButton.get() && ! acquisitionIsActive)
+    {
+        node->disconnectSocket();
+    }
 }
 
 void EphysSocketEditor::connected()
 {
-	connectButton->setVisible(false);
-	disconnectButton->setVisible(true);
+    connectButton->setVisible (false);
+    disconnectButton->setVisible (true);
 }
 
 void EphysSocketEditor::disconnected()
 {
-	connectButton->setVisible(true);
-	disconnectButton->setVisible(false);
+    connectButton->setVisible (true);
+    disconnectButton->setVisible (false);
 }

--- a/Source/EphysSocketEditor.h
+++ b/Source/EphysSocketEditor.h
@@ -14,7 +14,6 @@ namespace EphysSocketNode
     class EphysSocket;
 
     class EphysSocketEditor : public GenericEditor, 
-                              public Label::Listener,
                               public Button::Listener
     {
 
@@ -32,20 +31,11 @@ namespace EphysSocketNode
         /** Called by processor graph at the end of the acquisition, reenables editor completely. */
         void stopAcquisition();
 
-        /** Called when configuration is saved. Adds editors config to xml. */
-        void saveCustomParametersToXml(XmlElement* xml) override;
+        /** Called by the processor when the socket is connected. */
+        void connected();
 
-        /** Called when configuration is loaded. Reads editors config from xml. */
-        void loadCustomParametersFromXml(XmlElement* xml) override;
-
-        /** Called when label is changed */
-        void labelTextChanged(Label* label);
-
-        // Changes colors and disables UI elements
-        void disableInputs();
-
-        // Changes colors and enables UI elements
-        void enableInputs();
+        /** Called by the processor when the socket is disconnected. */
+        void disconnected();
 
     private:
 
@@ -55,22 +45,6 @@ namespace EphysSocketNode
 
         String stringConnect = "CONNECT";
         String stringDisconnect = "DISCONNECT";
-
-        // Port
-        std::unique_ptr<Label> portLabel;
-        std::unique_ptr<Label> portInput;
-
-        // Fs
-        std::unique_ptr<Label> sampleRateLabel;
-        std::unique_ptr<Label> sampleRateInput;
-
-        // Scale
-        std::unique_ptr<Label> scaleLabel;
-        std::unique_ptr<Label> scaleInput;
-
-        // Offset
-        std::unique_ptr<Label> offsetLabel;
-        std::unique_ptr<Label> offsetInput;
 
         // Parent node
         EphysSocket* node;

--- a/Source/EphysSocketEditor.h
+++ b/Source/EphysSocketEditor.h
@@ -11,46 +11,43 @@
 
 namespace EphysSocketNode
 {
-    class EphysSocket;
+class EphysSocket;
 
-    class EphysSocketEditor : public GenericEditor, 
-                              public Button::Listener
-    {
+class EphysSocketEditor : public GenericEditor,
+                          public Button::Listener
+{
+public:
+    /** Constructor */
+    EphysSocketEditor (GenericProcessor* parentNode, EphysSocket* node);
 
-    public:
+    /** Button listener callback, called by button when pressed. */
+    void buttonClicked (Button* button);
 
-        /** Constructor */
-        EphysSocketEditor(GenericProcessor* parentNode, EphysSocket *node);
+    /** Called by processor graph in beginning of the acquisition, disables editor completely. */
+    void startAcquisition();
 
-        /** Button listener callback, called by button when pressed. */
-        void buttonClicked(Button* button);
+    /** Called by processor graph at the end of the acquisition, reenables editor completely. */
+    void stopAcquisition();
 
-        /** Called by processor graph in beginning of the acquisition, disables editor completely. */
-        void startAcquisition();
+    /** Called by the processor when the socket is connected. */
+    void connected();
 
-        /** Called by processor graph at the end of the acquisition, reenables editor completely. */
-        void stopAcquisition();
+    /** Called by the processor when the socket is disconnected. */
+    void disconnected();
 
-        /** Called by the processor when the socket is connected. */
-        void connected();
+private:
+    // Button that connects/disconnects from/to server
+    std::unique_ptr<UtilityButton> connectButton;
+    std::unique_ptr<UtilityButton> disconnectButton;
 
-        /** Called by the processor when the socket is disconnected. */
-        void disconnected();
+    String stringConnect = "CONNECT";
+    String stringDisconnect = "DISCONNECT";
 
-    private:
+    // Parent node
+    EphysSocket* node;
 
-        // Button that connects/disconnects from/to server
-        std::unique_ptr<UtilityButton> connectButton;
-        std::unique_ptr<UtilityButton> disconnectButton;
-
-        String stringConnect = "CONNECT";
-        String stringDisconnect = "DISCONNECT";
-
-        // Parent node
-        EphysSocket* node;
-
-        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EphysSocketEditor);
-    };
-}
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (EphysSocketEditor);
+};
+} // namespace EphysSocketNode
 
 #endif

--- a/Source/EphysSocketHeader.cpp
+++ b/Source/EphysSocketHeader.cpp
@@ -12,27 +12,27 @@ EphysSocketHeader::EphysSocketHeader()
     num_samp = 512;
 }
 
-EphysSocketHeader::EphysSocketHeader(std::vector<std::byte>& header_bytes)
+EphysSocketHeader::EphysSocketHeader (std::vector<std::byte>& header_bytes)
 {
-    offset = (int)header_bytes[3] << 24 | (int)header_bytes[2] << 16 | (int)header_bytes[1] << 8 | (int)header_bytes[0];
-    num_bytes = (int)header_bytes[7] << 24 | (int)header_bytes[6] << 16 | (int)header_bytes[5] << 8 | (int)header_bytes[4];
-    depth = (Depth)((int)header_bytes[9] << 8 | (int)header_bytes[8]);
-    element_size = (int)header_bytes[13] << 24 | (int)header_bytes[12] << 16 | (int)header_bytes[11] << 8 | (int)header_bytes[10];
-    num_channels = (int)header_bytes[17] << 24 | (int)header_bytes[16] << 16 | (int)header_bytes[15] << 8 | (int)header_bytes[14];
-    num_samp = (int)header_bytes[21] << 24 | (int)header_bytes[20] << 16 | (int)header_bytes[19] << 8 | (int)header_bytes[18];
+    offset = (int) header_bytes[3] << 24 | (int) header_bytes[2] << 16 | (int) header_bytes[1] << 8 | (int) header_bytes[0];
+    num_bytes = (int) header_bytes[7] << 24 | (int) header_bytes[6] << 16 | (int) header_bytes[5] << 8 | (int) header_bytes[4];
+    depth = (Depth) ((int) header_bytes[9] << 8 | (int) header_bytes[8]);
+    element_size = (int) header_bytes[13] << 24 | (int) header_bytes[12] << 16 | (int) header_bytes[11] << 8 | (int) header_bytes[10];
+    num_channels = (int) header_bytes[17] << 24 | (int) header_bytes[16] << 16 | (int) header_bytes[15] << 8 | (int) header_bytes[14];
+    num_samp = (int) header_bytes[21] << 24 | (int) header_bytes[20] << 16 | (int) header_bytes[19] << 8 | (int) header_bytes[18];
 }
 
-EphysSocketHeader::EphysSocketHeader(std::vector<std::byte>& header_bytes, int _offset)
+EphysSocketHeader::EphysSocketHeader (std::vector<std::byte>& header_bytes, int _offset)
 {
-    offset = (int)header_bytes[_offset + 3] << 24 | (int)header_bytes[_offset + 2] << 16 | (int)header_bytes[_offset + 1] << 8 | (int)header_bytes[_offset + 0];
-    num_bytes = (int)header_bytes[_offset + 7] << 24 | (int)header_bytes[_offset + 6] << 16 | (int)header_bytes[_offset + 5] << 8 | (int)header_bytes[_offset + 4];
-    depth = (Depth)((int)header_bytes[_offset + 9] << 8 | (int)header_bytes[_offset + 8]);
-    element_size = (int)header_bytes[_offset + 13] << 24 | (int)header_bytes[_offset + 12] << 16 | (int)header_bytes[_offset + 11] << 8 | (int)header_bytes[_offset + 10];
-    num_channels = (int)header_bytes[_offset + 17] << 24 | (int)header_bytes[_offset + 16] << 16 | (int)header_bytes[_offset + 15] << 8 | (int)header_bytes[_offset + 14];
-    num_samp = (int)header_bytes[_offset + 21] << 24 | (int)header_bytes[_offset + 20] << 16 | (int)header_bytes[_offset + 19] << 8 | (int)header_bytes[_offset + 18];
+    offset = (int) header_bytes[_offset + 3] << 24 | (int) header_bytes[_offset + 2] << 16 | (int) header_bytes[_offset + 1] << 8 | (int) header_bytes[_offset + 0];
+    num_bytes = (int) header_bytes[_offset + 7] << 24 | (int) header_bytes[_offset + 6] << 16 | (int) header_bytes[_offset + 5] << 8 | (int) header_bytes[_offset + 4];
+    depth = (Depth) ((int) header_bytes[_offset + 9] << 8 | (int) header_bytes[_offset + 8]);
+    element_size = (int) header_bytes[_offset + 13] << 24 | (int) header_bytes[_offset + 12] << 16 | (int) header_bytes[_offset + 11] << 8 | (int) header_bytes[_offset + 10];
+    num_channels = (int) header_bytes[_offset + 17] << 24 | (int) header_bytes[_offset + 16] << 16 | (int) header_bytes[_offset + 15] << 8 | (int) header_bytes[_offset + 14];
+    num_samp = (int) header_bytes[_offset + 21] << 24 | (int) header_bytes[_offset + 20] << 16 | (int) header_bytes[_offset + 19] << 8 | (int) header_bytes[_offset + 18];
 }
 
-EphysSocketHeader::EphysSocketHeader(int _num_bytes, Depth _depth, int _element_size, int _num_samp, int _num_channels)
+EphysSocketHeader::EphysSocketHeader (int _num_bytes, Depth _depth, int _element_size, int _num_samp, int _num_channels)
 {
     offset = 0;
     num_bytes = _num_bytes;

--- a/Source/EphysSocketHeader.h
+++ b/Source/EphysSocketHeader.h
@@ -5,30 +5,38 @@
 
 namespace EphysSocketNode
 {
-	enum Depth { U8, S8, U16, S16, S32, F32, F64 };
+enum Depth
+{
+    U8,
+    S8,
+    U16,
+    S16,
+    S32,
+    F32,
+    F64
+};
 
-	/** Socket parameters */
-	const int HEADER_SIZE = 22;
+/** Socket parameters */
+const int HEADER_SIZE = 22;
 
-	struct EphysSocketHeader
-	{
-	public:
+struct EphysSocketHeader
+{
+public:
+    EphysSocketHeader();
 
-		EphysSocketHeader();
+    EphysSocketHeader (std::vector<std::byte>& header_bytes);
 
-		EphysSocketHeader(std::vector<std::byte>& header_bytes);
+    EphysSocketHeader (std::vector<std::byte>& header_bytes, int _offset);
 
-		EphysSocketHeader(std::vector<std::byte>& header_bytes, int _offset);
+    EphysSocketHeader (int _num_bytes, Depth _depth, int _element_size, int _num_samp, int _num_channels);
 
-		EphysSocketHeader(int _num_bytes, Depth _depth, int _element_size, int _num_samp, int _num_channels);
-
-		int offset;
-		int num_bytes;
-		Depth depth;
-		int element_size;
-		int num_samp;
-		int num_channels;
-	};
-}
+    int offset;
+    int num_bytes;
+    Depth depth;
+    int element_size;
+    int num_samp;
+    int num_channels;
+};
+} // namespace EphysSocketNode
 
 #endif

--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -38,7 +38,7 @@ extern "C" EXPORT void getLibInfo (Plugin::LibraryInfo* info)
 {
     info->apiVersion = PLUGIN_API_VER;
     info->name = "Ephys Socket";
-    info->libVersion = "0.4.0";
+    info->libVersion = "0.5.0";
     info->numPlugins = NUM_PLUGINS;
 }
 

--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -21,49 +21,49 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 */
 
-#include <PluginInfo.h>
 #include "EphysSocket.h"
+#include <PluginInfo.h>
 #include <string>
 #ifdef _WIN32
 #include <Windows.h>
-#define EXPORT __declspec(dllexport)
+#define EXPORT __declspec (dllexport)
 #else
-#define EXPORT __attribute__((visibility("default")))
+#define EXPORT __attribute__ ((visibility ("default")))
 #endif
 
 using namespace Plugin;
 #define NUM_PLUGINS 1
 
-extern "C" EXPORT void getLibInfo(Plugin::LibraryInfo* info)
+extern "C" EXPORT void getLibInfo (Plugin::LibraryInfo* info)
 {
-	info->apiVersion = PLUGIN_API_VER;
-	info->name = "Ephys Socket";
-	info->libVersion = "0.4.0";
-	info->numPlugins = NUM_PLUGINS;
+    info->apiVersion = PLUGIN_API_VER;
+    info->name = "Ephys Socket";
+    info->libVersion = "0.4.0";
+    info->numPlugins = NUM_PLUGINS;
 }
 
-extern "C" EXPORT int getPluginInfo(int index, Plugin::PluginInfo* info)
+extern "C" EXPORT int getPluginInfo (int index, Plugin::PluginInfo* info)
 {
-	switch (index)
-	{
-	case 0:
-		info->type = Plugin::Type::DATA_THREAD;
-		info->dataThread.name = "Ephys Socket";
-		info->dataThread.creator = &createDataThread<EphysSocketNode::EphysSocket>;
-		break;
-	default:
-		return -1;
-		break;
-	}
-	return 0;
+    switch (index)
+    {
+        case 0:
+            info->type = Plugin::Type::DATA_THREAD;
+            info->dataThread.name = "Ephys Socket";
+            info->dataThread.creator = &createDataThread<EphysSocketNode::EphysSocket>;
+            break;
+        default:
+            return -1;
+            break;
+    }
+    return 0;
 }
 
 #ifdef WIN32
-BOOL WINAPI DllMain(IN HINSTANCE hDllHandle,
-	IN DWORD     nReason,
-	IN LPVOID    Reserved)
+BOOL WINAPI DllMain (IN HINSTANCE hDllHandle,
+                     IN DWORD nReason,
+                     IN LPVOID Reserved)
 {
-	return TRUE;
+    return TRUE;
 }
 
 #endif

--- a/Source/SocketThread.cpp
+++ b/Source/SocketThread.cpp
@@ -30,7 +30,7 @@ SocketThread::SocketThread (String name, EphysSocket* processor_)
 
 SocketThread::~SocketThread()
 {
-    stopThread (500);
+    stopThread (1000);
 
     if (socket != nullptr)
     {
@@ -75,7 +75,7 @@ bool SocketThread::connectSocket (int port, bool printOutput)
     error_flag = false;
 
     socket = std::make_unique<StreamingSocket>();
-    connected = socket->connect ("localhost", port);
+    connected = socket->connect ("localhost", port, 250);
 
     if (connected)
     {

--- a/Source/SocketThread.cpp
+++ b/Source/SocketThread.cpp
@@ -2,319 +2,329 @@
 #include <Windows.h>
 #endif
 
-#include "SocketThread.h"
 #include "EphysSocket.h"
+#include "SocketThread.h"
 
 using namespace EphysSocketNode;
 
-SocketThread::SocketThread(String name, EphysSocket* processor_)
-	: Thread(name), processor(processor_)
+SocketThread::SocketThread (String name, EphysSocket* processor_)
+    : Thread (name), processor (processor_)
 {
-	lastPacketReceived = time(nullptr);
+    lastPacketReceived = time (nullptr);
 
-	socket = nullptr;
+    socket = nullptr;
 
-	previousPort = -1;
+    previousPort = -1;
 
-	depth = DEFAULT_DEPTH;
-	element_size = DEFAULT_ELEMENT_SIZE;
-	num_bytes = DEFAULT_NUM_BYTES;
-	num_channels = DEFAULT_NUM_CHANNELS;
-	num_samp = DEFAULT_NUM_SAMPLES;
+    depth = DEFAULT_DEPTH;
+    element_size = DEFAULT_ELEMENT_SIZE;
+    num_bytes = DEFAULT_NUM_BYTES;
+    num_channels = DEFAULT_NUM_CHANNELS;
+    num_samp = DEFAULT_NUM_SAMPLES;
 
-	error_flag = false;
-	connected = false;
-	shouldReconnect = false;
-	acquiring = false;
+    error_flag = false;
+    connected = false;
+    shouldReconnect = false;
+    acquiring = false;
 }
 
 SocketThread::~SocketThread()
 {
-	stopThread(500);
+    stopThread (500);
 
-	if (socket != nullptr)
-	{
-		socket->close();
-		socket.reset();
-	}
+    if (socket != nullptr)
+    {
+        socket->close();
+        socket.reset();
+    }
 }
 
 void SocketThread::startAcquisition()
 {
-	acquiring = true;
+    acquiring = true;
 }
 
 void SocketThread::stopAcquisition()
 {
-	acquiring = false;
+    acquiring = false;
 }
 
-bool SocketThread::connectSocket(int port, bool printOutput)
+bool SocketThread::connectSocket (int port, bool printOutput)
 {
-	if (port == -1)
-	{
-		if (previousPort != -1) {
-			port = previousPort;
-		}
-		else {
-			LOGE("Must give a valid port number for the first connection.");
-			return false;
-		}
-	}
+    if (port == -1)
+    {
+        if (previousPort != -1)
+        {
+            port = previousPort;
+        }
+        else
+        {
+            LOGE ("Must give a valid port number for the first connection.");
+            return false;
+        }
+    }
 
-	std::lock_guard<std::mutex> lock(socketMutex);
+    std::lock_guard<std::mutex> lock (socketMutex);
 
-	if (socket != nullptr && socket->isConnected())
-	{
-		LOGE("Attempting to connect to an already active socket.");
-		return false;
-	}
+    if (socket != nullptr && socket->isConnected())
+    {
+        LOGE ("Attempting to connect to an already active socket.");
+        return false;
+    }
 
-	error_flag = false;
+    error_flag = false;
 
-	socket = std::make_unique<StreamingSocket>();
-	connected = socket->connect("localhost", port);
+    socket = std::make_unique<StreamingSocket>();
+    connected = socket->connect ("localhost", port);
 
-	if (connected)
-	{
-		std::vector<std::byte> header_bytes(HEADER_SIZE);
+    if (connected)
+    {
+        std::vector<std::byte> header_bytes (HEADER_SIZE);
 
-		LOGD("Reading header...");
-		int rc;
+        LOGD ("Reading header...");
+        int rc;
 
-		for (int i = 0; i < 5; i++) {
-			rc = socket->read(header_bytes.data(), HEADER_SIZE, false);
+        for (int i = 0; i < 5; i++)
+        {
+            rc = socket->read (header_bytes.data(), HEADER_SIZE, false);
 
-			if (rc == HEADER_SIZE) break;
-			else sleep(100);
-		}
+            if (rc == HEADER_SIZE)
+                break;
+            else
+                sleep (100);
+        }
 
-		if (rc != HEADER_SIZE)
-		{
-			if (printOutput)
-			{
-				LOGC("EphysSocket failed to connect; could not read header from stream. Bytes read: ", rc);
-				CoreServices::sendStatusMessage("Ephys Socket: Could not read stream.");
-			}
+        if (rc != HEADER_SIZE)
+        {
+            if (printOutput)
+            {
+                LOGC ("EphysSocket failed to connect; could not read header from stream. Bytes read: ", rc);
+                CoreServices::sendStatusMessage ("Ephys Socket: Could not read stream.");
+            }
 
-			socket->close();
-			socket.reset();
+            socket->close();
+            socket.reset();
 
-			connected = false;
+            connected = false;
 
-			return false;
-		}
+            return false;
+        }
 
-		EphysSocketHeader tmp_header = EphysSocketHeader(header_bytes);
-		LOGD("Header read and parsed correctly.");
+        EphysSocketHeader tmp_header = EphysSocketHeader (header_bytes);
+        LOGD ("Header read and parsed correctly.");
 
-		num_bytes = tmp_header.num_bytes;
-		element_size = tmp_header.element_size;
-		depth = tmp_header.depth;
-		num_samp = tmp_header.num_samp;
-		num_channels = tmp_header.num_channels;
+        num_bytes = tmp_header.num_bytes;
+        element_size = tmp_header.element_size;
+        depth = tmp_header.depth;
+        num_samp = tmp_header.num_samp;
+        num_channels = tmp_header.num_channels;
 
-		const int matrix_size = num_channels * num_samp * element_size;
-		header_bytes.reserve(matrix_size);
-		socket->read(header_bytes.data(), matrix_size, true); // NB: Realign stream to the beginning of a packet
+        const int matrix_size = num_channels * num_samp * element_size;
+        header_bytes.reserve (matrix_size);
+        socket->read (header_bytes.data(), matrix_size, true); // NB: Realign stream to the beginning of a packet
 
-		lastPacketReceived = time(nullptr);
+        lastPacketReceived = time (nullptr);
 
-		previousPort = port;
+        previousPort = port;
 
-		if (printOutput)
-		{
-			LOGC("EphysSocket connected.");
-			CoreServices::sendStatusMessage("Ephys Socket: Socket connected.");
-		}
+        if (printOutput)
+        {
+            LOGC ("EphysSocket connected.");
+            CoreServices::sendStatusMessage ("Ephys Socket: Socket connected.");
+        }
 
-		read_buffer.resize(num_channels * num_samp * element_size + HEADER_SIZE);
+        read_buffer.resize (num_channels * num_samp * element_size + HEADER_SIZE);
 
-		shouldReconnect = false;
+        shouldReconnect = false;
 
-		bool result = startThread();
+        bool result = startThread();
 
-		return true;
-	}
-	else
-	{
-		if (printOutput)
-		{
-			LOGC("EphysSocket failed to connect");
-			CoreServices::sendStatusMessage("Ephys Socket: Could not connect.");
-		}
+        return true;
+    }
+    else
+    {
+        if (printOutput)
+        {
+            LOGC ("EphysSocket failed to connect");
+            CoreServices::sendStatusMessage ("Ephys Socket: Could not connect.");
+        }
 
-		return false;
-	}
+        return false;
+    }
 }
 
 void SocketThread::disconnectSocket()
 {
-	std::lock_guard<std::mutex> lock(socketMutex);
+    std::lock_guard<std::mutex> lock (socketMutex);
 
-	if (socket != nullptr)
-	{
-		LOGD("Disconnecting socket.");
+    if (socket != nullptr)
+    {
+        LOGD ("Disconnecting socket.");
 
-		socket->close();
-		socket.reset();
+        socket->close();
+        socket.reset();
 
-		CoreServices::sendStatusMessage("Ephys Socket: Disconnected.");
-	}
+        CoreServices::sendStatusMessage ("Ephys Socket: Disconnected.");
+    }
 
-	connected = false;
-	shouldReconnect = false;
+    connected = false;
+    shouldReconnect = false;
 }
 
 bool SocketThread::isConnected()
 {
-	return connected;
+    return connected;
 }
 
 bool SocketThread::isError() const
 {
-	return error_flag;
+    return error_flag;
 }
 
-bool SocketThread::compareHeaders(EphysSocketHeader header) const
+bool SocketThread::compareHeaders (EphysSocketHeader header) const
 {
-	if (header.depth != depth ||
-		header.element_size != element_size ||
-		header.num_channels != num_channels ||
-		header.num_samp != num_samp)
-	{
-		return false;
-	}
+    if (header.depth != depth || header.element_size != element_size || header.num_channels != num_channels || header.num_samp != num_samp)
+    {
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
 void SocketThread::attemptToReconnect()
 {
-	auto previousHeader = EphysSocketHeader(num_bytes, depth, element_size, num_samp, num_channels);
+    auto previousHeader = EphysSocketHeader (num_bytes, depth, element_size, num_samp, num_channels);
 
-	if (connectSocket(previousPort, false))
-	{
-		shouldReconnect = false;
+    if (connectSocket (previousPort, false))
+    {
+        shouldReconnect = false;
 
-		if (!compareHeaders(previousHeader))
-		{
-			disconnectSocket();
-			LOGE("Mismatched header, disconnecting socket.");
-			CoreServices::sendStatusMessage("Ephys Socket: Invalid header, disconnecting.");
-			error_flag = true;
-			return;
-		}
+        if (! compareHeaders (previousHeader))
+        {
+            disconnectSocket();
+            LOGE ("Mismatched header, disconnecting socket.");
+            CoreServices::sendStatusMessage ("Ephys Socket: Invalid header, disconnecting.");
+            error_flag = true;
+            return;
+        }
 
-		LOGD("Successfully reconnected the socket.");
-		CoreServices::sendStatusMessage("Ephys Socket: Socket reconnected.");
-		lastPacketReceived = time(nullptr);
-	}
+        LOGD ("Successfully reconnected the socket.");
+        CoreServices::sendStatusMessage ("Ephys Socket: Socket reconnected.");
+        lastPacketReceived = time (nullptr);
+    }
 }
 
 void SocketThread::run()
 {
-	while (!threadShouldExit())
-	{
-		if (connected)
-		{
-			if (error_flag) {
-				const MessageManagerLock mmLock;
-				processor->disconnectSocket();
-				return;
-			}
+    while (! threadShouldExit())
+    {
+        if (connected)
+        {
+            if (error_flag)
+            {
+                const MessageManagerLock mmLock;
+                processor->disconnectSocket();
+                return;
+            }
 
-			std::lock_guard<std::mutex> lock(socketMutex);
+            std::lock_guard<std::mutex> lock (socketMutex);
 
-			const int bytes_expected = num_channels * num_samp * element_size + HEADER_SIZE;
+            const int bytes_expected = num_channels * num_samp * element_size + HEADER_SIZE;
 
-			int rc;
-			EphysSocketHeader header;
+            int rc;
+            EphysSocketHeader header;
 
-			if (socket != nullptr && socket->isConnected()) {
-				rc = socket->read(read_buffer.data(), bytes_expected, false);
-			}
-			else {
-				rc = 0; // NB: This will attempt to reconnect the socket below
-			}
+            if (socket != nullptr && socket->isConnected())
+            {
+                rc = socket->read (read_buffer.data(), bytes_expected, false);
+            }
+            else
+            {
+                rc = 0; // NB: This will attempt to reconnect the socket below
+            }
 
-			if (rc == -1)
-			{
-				if (socket->getRawSocketHandle() == -1)
-				{
-					CoreServices::sendStatusMessage("Ephys Socket: Socket handle invalid.");
-					LOGE("Ephys Socket: Socket handle is invalid");
-					error_flag = true;
-					continue;
-				}
-				else
-				{
-					CoreServices::sendStatusMessage("Ephys Socket: Socket read error");
-					LOGE("Ephys Socket: Reading from socket did not complete");
-					error_flag = true;
-					continue;
-				}
-			}
-			else if (rc == 0)
-			{
-				if (difftime(time(nullptr), lastPacketReceived) >= 2)
-				{
-					LOGD("Last packet was too old.");
+            if (rc == -1)
+            {
+                if (socket->getRawSocketHandle() == -1)
+                {
+                    CoreServices::sendStatusMessage ("Ephys Socket: Socket handle invalid.");
+                    LOGE ("Ephys Socket: Socket handle is invalid");
+                    error_flag = true;
+                    continue;
+                }
+                else
+                {
+                    CoreServices::sendStatusMessage ("Ephys Socket: Socket read error");
+                    LOGE ("Ephys Socket: Reading from socket did not complete");
+                    error_flag = true;
+                    continue;
+                }
+            }
+            else if (rc == 0)
+            {
+                if (difftime (time (nullptr), lastPacketReceived) >= 2)
+                {
+                    LOGD ("Last packet was too old.");
 
-					socket->close();
-					socket.reset();
+                    socket->close();
+                    socket.reset();
 
-					connected = false;
-					shouldReconnect = true;
+                    connected = false;
+                    shouldReconnect = true;
 
-					LOGC("EphysSocket has been disconnected. Attempting to reconnect now.");
-					CoreServices::sendStatusMessage("Ephys Socket: Attempting to reconnect...");
-				}
+                    LOGC ("EphysSocket has been disconnected. Attempting to reconnect now.");
+                    CoreServices::sendStatusMessage ("Ephys Socket: Attempting to reconnect...");
+                }
 
-				continue;
-			}
-			else if (rc != bytes_expected)
-			{
-				int bytes_received = rc;
+                continue;
+            }
+            else if (rc != bytes_expected)
+            {
+                int bytes_received = rc;
 
-				while (bytes_received < bytes_expected)
-				{
-					rc = socket->read(read_buffer.data() + bytes_received, bytes_expected - bytes_received, false);
+                while (bytes_received < bytes_expected)
+                {
+                    rc = socket->read (read_buffer.data() + bytes_received, bytes_expected - bytes_received, false);
 
-					if (rc != 0) {
-						bytes_received += rc;
-					}
+                    if (rc != 0)
+                    {
+                        bytes_received += rc;
+                    }
 
-					if (threadShouldExit()) {
-						return;
-					}
-				}
-			}
+                    if (threadShouldExit())
+                    {
+                        return;
+                    }
+                }
+            }
 
-			header = EphysSocketHeader(read_buffer);
+            header = EphysSocketHeader (read_buffer);
 
-			if (!compareHeaders(header))
-			{
-				CoreServices::sendStatusMessage("Ephys Socket: Invalid header");
-				LOGE("Ephys Socket: Header values have changed since first connecting");
-				error_flag = true;
-				continue;
-			}
+            if (! compareHeaders (header))
+            {
+                CoreServices::sendStatusMessage ("Ephys Socket: Invalid header");
+                LOGE ("Ephys Socket: Header values have changed since first connecting");
+                error_flag = true;
+                continue;
+            }
 
-			lastPacketReceived = time(nullptr);
+            lastPacketReceived = time (nullptr);
 
-			if (acquiring) {
-				data.add(read_buffer);
-			}
-		}
-		else if (shouldReconnect) {
-			attemptToReconnect();
+            if (acquiring)
+            {
+                data.add (read_buffer);
+            }
+        }
+        else if (shouldReconnect)
+        {
+            attemptToReconnect();
 
-			if (error_flag) {
-				const MessageManagerLock mmLock;
-				processor->disconnectSocket();
-				return;
-			}
-		}
-	}
+            if (error_flag)
+            {
+                const MessageManagerLock mmLock;
+                processor->disconnectSocket();
+                return;
+            }
+        }
+    }
 }

--- a/Source/SocketThread.h
+++ b/Source/SocketThread.h
@@ -26,17 +26,18 @@
 
 #include <DataThreadHeaders.h>
 #include "EphysSocketHeader.h"
-#include "EphysSocketEditor.h"
 
 #include <atomic>
 
 namespace EphysSocketNode
 {
+	class EphysSocket;
+	
 	class SocketThread : public Thread
 	{
 	public:
 
-		SocketThread(String name);
+		SocketThread(String name, EphysSocket* processor);
 
 		~SocketThread();
 
@@ -56,8 +57,6 @@ namespace EphysSocketNode
 		bool isError() const;
 
 		bool isConnected();
-
-		void setEditor(EphysSocketEditor* ed);
 
 		Array<std::vector<std::byte>, CriticalSection, 10> data;
 
@@ -85,7 +84,7 @@ namespace EphysSocketNode
 		void attemptToReconnect();
 
 		/** Pointer to the editor */
-		EphysSocketEditor* editor;
+		EphysSocket* processor;
 
 		/** TCP Socket object */
 		std::unique_ptr<StreamingSocket> socket;

--- a/Source/SocketThread.h
+++ b/Source/SocketThread.h
@@ -24,88 +24,86 @@
 #ifndef __SOCKET_H__
 #define __SOCKET_H__
 
-#include <DataThreadHeaders.h>
 #include "EphysSocketHeader.h"
+#include <DataThreadHeaders.h>
 
 #include <atomic>
 
 namespace EphysSocketNode
 {
-	class EphysSocket;
-	
-	class SocketThread : public Thread
-	{
-	public:
+class EphysSocket;
 
-		SocketThread(String name, EphysSocket* processor);
+class SocketThread : public Thread
+{
+public:
+    SocketThread (String name, EphysSocket* processor);
 
-		~SocketThread();
+    ~SocketThread();
 
-		/** Starts probe data streaming */
-		void startAcquisition();
+    /** Starts probe data streaming */
+    void startAcquisition();
 
-		/** Stops probe data streaming*/
-		void stopAcquisition();
+    /** Stops probe data streaming*/
+    void stopAcquisition();
 
-		/** Attempts to connect to the socket */
-		bool connectSocket(int port, bool printOutput = true);
+    /** Attempts to connect to the socket */
+    bool connectSocket (int port, bool printOutput = true);
 
-		/** Disconnects the socket */
-		void disconnectSocket();
+    /** Disconnects the socket */
+    void disconnectSocket();
 
-		/** Returns if any errors were thrown during acquisition, such as invalid headers or unable to read from socket */
-		bool isError() const;
+    /** Returns if any errors were thrown during acquisition, such as invalid headers or unable to read from socket */
+    bool isError() const;
 
-		bool isConnected();
+    bool isConnected();
 
-		Array<std::vector<std::byte>, CriticalSection, 10> data;
+    Array<std::vector<std::byte>, CriticalSection, 10> data;
 
-		/** Variables that are part of the incoming header */
-		int num_bytes;
-		int element_size;
-		Depth depth;
-		int num_samp;
-		int num_channels;
+    /** Variables that are part of the incoming header */
+    int num_bytes;
+    int element_size;
+    Depth depth;
+    int num_samp;
+    int num_channels;
 
-	private:
+private:
+    /** Default socket parameters */
+    const int DEFAULT_NUM_SAMPLES = 256;
+    const int DEFAULT_NUM_CHANNELS = 64;
+    const Depth DEFAULT_DEPTH = U16;
+    const int DEFAULT_NUM_BYTES = 32678; // NB: 256 * 64 * 2
+    const int DEFAULT_ELEMENT_SIZE = 2;
 
-		/** Default socket parameters */
-		const int DEFAULT_NUM_SAMPLES = 256;
-		const int DEFAULT_NUM_CHANNELS = 64;
-		const Depth DEFAULT_DEPTH = U16;
-		const int DEFAULT_NUM_BYTES = 32678; // NB: 256 * 64 * 2
-		const int DEFAULT_ELEMENT_SIZE = 2;
+    void run() override;
 
-		void run() override;
+    /** Compares a newly parsed header to existing variables */
+    bool compareHeaders (EphysSocketHeader header) const;
 
-		/** Compares a newly parsed header to existing variables */
-		bool compareHeaders(EphysSocketHeader header) const;
+    void attemptToReconnect();
 
-		void attemptToReconnect();
+    /** Pointer to the editor */
+    EphysSocket* processor;
 
-		/** Pointer to the editor */
-		EphysSocket* processor;
+    /** TCP Socket object */
+    std::unique_ptr<StreamingSocket> socket;
 
-		/** TCP Socket object */
-		std::unique_ptr<StreamingSocket> socket;
+    /** Mutex for thread safety */
+    std::mutex socketMutex;
 
-		/** Mutex for thread safety */
-		std::mutex socketMutex;
+    /** Internal buffers */
+    std::vector<std::byte> read_buffer;
 
-		/** Internal buffers */
-		std::vector<std::byte> read_buffer;
+    std::atomic<bool> connected;
+    std::atomic<bool> shouldReconnect;
+    std::atomic<bool> acquiring;
+    std::atomic<bool> error_flag;
 
-		std::atomic<bool> connected;
-		std::atomic<bool> shouldReconnect;
-		std::atomic<bool> acquiring;
-		std::atomic<bool> error_flag;
+    std::time_t lastPacketReceived;
 
-		std::time_t lastPacketReceived;
+    int previousPort;
 
-		int previousPort;
-
-		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SocketThread);
-	};
-}
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SocketThread);
+};
+} // namespace EphysSocketNode
 
 #endif // !__SOCKET_H__


### PR DESCRIPTION
This pull request includes updates to the build workflows, formatting configurations, and refactoring the source code to use parameters and parameter editors. 

### Source Improvements:
* Refactored to use parameters and parameter editors, and handle parameter value changes accordingly
* Updated the socket connection logic to enable/disable parameters based on the connection status. 

### GitHub Workflows Updates:
* Swapped `juce8` and `testing-juce8` branches. Similar to other plugins, updated to use the `juce8` branch for development and `testing-juce8` branch for deploying. 
* Updated the macOS deployment process to include code signing and notarization steps.

### Formatting and Configuration:
* `.clang-format`: Added a new formatting configuration file for C++ code, used by the GUI and all the other plugins.

### Build Configuration:
* `CMakeLists.txt`: Updated the macOS architecture settings to support both `arm64` and `x86_64`, and changed the rpath for shared libraries. 

### Error Handling:
* Python example code: Added error handling for `BrokenPipeError` to gracefully handle connection closures.

These changes are exclusively intended for GUI v1.0.0.